### PR TITLE
turned auto release off

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 				<configuration>
 					<serverId>ossrh</serverId>
 					<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+					<autoReleaseAfterClose>false</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Auto release determines whether we sync with Maven immediately after a successful deploy. Turning it to false will give us a second opportunity to confirm that we are ready to release.