### PR TITLE
[BCLOUD-4852] don't parse body for non 200 http status code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.bitheads</groupId>
 	<artifactId>brainclouds2s</artifactId>
-	<version>4.14.3</version>
+	<version>4.14.4</version>
 	<packaging>jar</packaging>
 	<name>brainCloud S2S Java</name>
 	<description>The Java library for brainCloud S2S</description>

--- a/src/main/java/com/bitheads/brainclouds2s/BrainCloudS2S.java
+++ b/src/main/java/com/bitheads/brainclouds2s/BrainCloudS2S.java
@@ -425,7 +425,13 @@ public class BrainCloudS2S implements Runnable {
 			synchronized(_lock) {
 				try {
 					_responseCode = connection.getResponseCode();
-					_jsonResponse = new JSONObject(responseBody);
+					if (_responseCode == HttpURLConnection.HTTP_OK) {
+						_jsonResponse = new JSONObject(responseBody);
+					}
+					else {
+						logString("ERROR making request [status:" + _responseCode + "]");
+						_jsonResponse = generateError(CLIENT_NETWORK_ERROR, INVALID_RESPONSE, responseBody);
+					}
 				}
 				catch (IOException e) {
 					logException("ERROR reading response code", e);


### PR DESCRIPTION
No need to parse json that won't be there.