### PR TITLE
[BCLOUD-5657] Fix for broken reconnect on session expired error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.bitheads</groupId>
 	<artifactId>brainclouds2s</artifactId>
-	<version>4.15.0</version>
+	<version>4.15.1</version>
 	<packaging>jar</packaging>
 	<name>brainCloud S2S Java</name>
 	<description>The Java library for brainCloud S2S</description>

--- a/src/main/java/com/bitheads/brainclouds2s/BrainCloudS2S.java
+++ b/src/main/java/com/bitheads/brainclouds2s/BrainCloudS2S.java
@@ -425,7 +425,7 @@ public class BrainCloudS2S implements Runnable {
 			synchronized(_lock) {
 				try {
 					_responseCode = connection.getResponseCode();
-					if (_responseCode == HttpURLConnection.HTTP_OK) {
+					if (_responseCode == HttpURLConnection.HTTP_OK || _responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
 						_jsonResponse = new JSONObject(responseBody);
 					}
 					else {


### PR DESCRIPTION
The issue is that the error format returned by the existing version prevents the callback from recognizing the expired session error.